### PR TITLE
Fixed PATCH HTTP Verb issues from swagger definition

### DIFF
--- a/maas.openapi2.yml
+++ b/maas.openapi2.yml
@@ -22,12 +22,12 @@ paths:
       summary: Logs a user in and returns an JWT token for authentication
       description: Logs a user in and returns an JWT token for authentication. The passes along validitiyseconds determine how long the token should be available.
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       parameters:
         - in: formData
           name: username
           type: string
-          required: true 
+          required: true
         - in: formData
           name: password
           type: string
@@ -35,7 +35,7 @@ paths:
         - in: formData
           name: validityseconds
           type: integer
-          minimum: 0          
+          minimum: 0
       responses:
         200:
           description: Success
@@ -72,14 +72,14 @@ paths:
       summary: Add a new item
       description: Adds a new item to matomat. This can only be done by admins
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
         - in: formData
           name: name
           type: string
-          required: true 
+          required: true
         - in: formData
           name: cost
           type: integer
@@ -103,7 +103,7 @@ paths:
       summary: Get consumption stats of all items
       description: Get the matomat stats for all items
       produces:
-        - application/json      
+        - application/json
       responses:
         200:
           description: Success
@@ -130,17 +130,17 @@ paths:
       summary: Get a certain Item
       description: Get a certain Item
       produces:
-        - application/json      
+        - application/json
       responses:
         200:
           description: successful operation
-          schema:          
+          schema:
             $ref: '#/definitions/Item'
         default:
           description: An error occured
           schema:
             $ref: '#/definitions/Error'
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -148,23 +148,23 @@ paths:
       summary: Update Item
       description: Update Item. This can only be done by admins
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       produces:
-        - application/json      
+        - application/json
       parameters:
         - in: formData
           name: name
           type: string
-          required: true 
+          required: true
         - in: formData
           name: cost
           type: integer
           minimum: 0
-          required: true        
+          required: true
       responses:
         200:
           description: Success
-          schema:          
+          schema:
             $ref: '#/definitions/Item'
         default:
           description: An error occured
@@ -178,18 +178,18 @@ paths:
       summary: Delete Item
       description: Delete the Item. This can only be done by admins. (Should only mark a Item as deleted to not loose reference for stats)
       produces:
-        - application/json      
+        - application/json
       responses:
         200:
           description: Success. Returns the deleted item object
-          schema:          
+          schema:
             $ref: '#/definitions/Item'
         default:
           description: An error occured
           schema:
             $ref: '#/definitions/Error'
   /items/{itemId}/consume:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -197,7 +197,7 @@ paths:
       summary: Consumes a Item
       description: Consumes a Item and subtracts the cost of the Item from the credit of the user. If not enough credit exists the operation will be rejected
       produces:
-        - application/json      
+        - application/json
       parameters:
         - in: path
           name: itemId
@@ -207,7 +207,7 @@ paths:
       responses:
         200:
           description: Success
-          schema:          
+          schema:
             $ref: '#/definitions/ItemStats'
         412:
           description: Not enough credits to consume Item
@@ -226,7 +226,7 @@ paths:
       summary: Get consumption stats
       description: Get the matomat stats for a certain Item
       produces:
-        - application/json      
+        - application/json
       parameters:
         - in: path
           name: itemId
@@ -271,14 +271,14 @@ paths:
       summary: Add a new user
       description: Add a new user. Only admin users are allowed to do this. If "admin" is greater than 0, the new user will be created as admin user.
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
         - in: formData
           name: name
           type: string
-          required: true 
+          required: true
         - in: formData
           name: password
           type: string
@@ -344,7 +344,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /users/{userId}/credits/add:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -352,7 +352,7 @@ paths:
       summary: Add users credits
       description: Add users credits. This can only be done by the logged in user
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -365,7 +365,7 @@ paths:
           name: credits
           type: integer
           minimum: 0
-          required: true     
+          required: true
       responses:
         200:
           description: Success
@@ -376,7 +376,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /users/{userId}/credits/withdraw:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -404,7 +404,7 @@ paths:
           schema:
             $ref: '#/definitions/User'
         412:
-          description: Not enough credits to withdraw desired amount      
+          description: Not enough credits to withdraw desired amount
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -412,7 +412,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /users/{userId}/credits/transfer:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -420,7 +420,7 @@ paths:
       summary: Transfer credits
       description: Transfers credits from logged in user to given user
       consumes:
-        - application/x-www-form-urlencoded      
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -473,7 +473,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /users/{userId}/password:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -497,7 +497,7 @@ paths:
         - in: formData
           name: passwordnew
           type: string
-          required: true          
+          required: true
         - in: formData
           name: passwordrepeat
           type: string
@@ -512,7 +512,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /users/{userId}/resetpassword:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -532,7 +532,7 @@ paths:
         - in: formData
           name: passwordnew
           type: string
-          required: true          
+          required: true
         - in: formData
           name: passwordrepeat
           type: string
@@ -552,7 +552,7 @@ paths:
       - jwtTokenAuth: []
       tags:
       - service
-      summary: Total service stats 
+      summary: Total service stats
       description: Total service stats
       produces:
         - application/json
@@ -580,7 +580,7 @@ definitions:
         type: integer
         format: int32
       user:
-        $ref: '#/definitions/User'   
+        $ref: '#/definitions/User'
   User:
     type: object
     properties:
@@ -616,7 +616,7 @@ definitions:
         type: integer
         format: int32
       name:
-        type: string          
+        type: string
       cost:
         type: integer
         format: int32
@@ -662,7 +662,7 @@ definitions:
         properties:
           count:
             type: integer
-            format: int32                
+            format: int32
           credits:
             type: object
             properties:

--- a/maas.yml
+++ b/maas.yml
@@ -49,7 +49,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AuthSuccess'          
+                  $ref: '#/components/schemas/AuthSuccess'
         400:
           description: Invalid username/password supplied
   /items:
@@ -100,7 +100,7 @@ paths:
                   minimum: 0
               required:
                 - name
-                - cost              
+                - cost
       responses:
         201:
           description: Created
@@ -158,7 +158,7 @@ paths:
           description: successful operation
           content:
             application/json:
-              schema:          
+              schema:
                 $ref: '#/components/schemas/Item'
         default:
           description: An error occured
@@ -166,7 +166,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -199,13 +199,13 @@ paths:
                   minimum: 0
               required:
                 - name
-                - cost 
+                - cost
       responses:
         200:
           description: Success
           content:
             application/json:
-              schema:          
+              schema:
                 $ref: '#/components/schemas/Item'
         default:
           description: An error occured
@@ -233,7 +233,7 @@ paths:
           description: Success. Returns the deleted item object
           content:
             application/json:
-              schema:          
+              schema:
                 $ref: '#/components/schemas/Item'
         default:
           description: An error occured
@@ -242,7 +242,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /items/{itemId}/consume:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -262,12 +262,12 @@ paths:
           description: Success
           content:
             application/json:
-              schema:          
+              schema:
                 $ref: '#/components/schemas/ItemStats'
         412:
           description: Not enough credits to consume Item
           content:
-            application/json:          
+            application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
@@ -280,7 +280,7 @@ paths:
     get:
       security:
       - jwtTokenAuth: []
-      tags:      
+      tags:
       - items
       summary: Get consumption stats
       description: Get the matomat stats for a certain Item
@@ -428,7 +428,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /users/{userId}/credits/add:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -510,7 +510,7 @@ paths:
         412:
           description: Not enough credits to withdraw desired amount
           content:
-            application/json:          
+            application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
@@ -520,7 +520,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /users/{userId}/credits/transfer:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -548,7 +548,7 @@ paths:
                   format: int32
                   minimum: 0
               required:
-                - credits        
+                - credits
       responses:
         200:
           description: Success
@@ -559,7 +559,7 @@ paths:
         412:
           description: Not enough credits to transfer desired amount
           content:
-            application/json:          
+            application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
@@ -598,7 +598,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /users/{userId}/password:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -645,7 +645,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /users/{userId}/resetpassword:
-    patch:
+    put:
       security:
       - jwtTokenAuth: []
       tags:
@@ -694,7 +694,7 @@ paths:
       - jwtTokenAuth: []
       tags:
       - service
-      summary: Total service stats 
+      summary: Total service stats
       description: Total service stats
       responses:
         200:
@@ -761,7 +761,7 @@ components:
           type: integer
           format: int32
         name:
-          type: string          
+          type: string
         cost:
           type: integer
           format: int32
@@ -807,7 +807,7 @@ components:
           properties:
             count:
               type: integer
-              format: int32                
+              format: int32
             credits:
               type: object
               properties:


### PR DESCRIPTION
Hi

I wanted to:

* Add credits
* Change user passwords
* Consume itmes

By implementing this using the swagger generated client, i stumbled upon 404 Errors against the backend. To debug this I manually crafted a http request 

```
> http --verify=no PATCH https://localhost:8443/v0/items/1/consume Authorization:Bearer=xxx                                                                                                                                      
HTTP/1.1 404 Not Found
404 page not found
```

Where as PUT works.

```
> http --verify=no PUT https://localhost:8443/v0/items/1/consume Authorization:Bearer=xxx
```

I found out that the swagger file defines the API as `PATCH` whereas the actual backend code implements endpoints with `PUT`

For reference, see Method definitions here:

```
maas-server/api/items_api.go
128:func (iah *ItemsApiHandler) ItemsItemidPut(w http.ResponseWriter, r *http.Request) {
245:func (iah *ItemsApiHandler) ItemsItemidConsumePut(w http.ResponseWriter, r *http.Request) {

maas-server/api/users_api.go
183:func (uah *UsersApiHandler) UsersUseridCreditsAddPut(w http.ResponseWriter, r *http.Request) {
211:func (uah *UsersApiHandler) UsersUseridCreditsWithdrawPut(w http.ResponseWriter, r *http.Request) {
275:func (uah *UsersApiHandler) UsersUseridCreditsTransferPut(w http.ResponseWriter, r *http.Request) {
303:func (uah *UsersApiHandler) UsersPasswordPut(w http.ResponseWriter, r *http.Request) {
328:func (uah *UsersApiHandler) UsersUseridPasswordPut(w http.ResponseWriter, r *http.Request) {
```

In this PR I updated the swagger files to match the backend. (And some whitespace fixes my editor did automatically, which im sorry for messing up this commit a little)