### PR TITLE
Schema definition for user_items_stats was not using a composite key

### DIFF
--- a/maas-server/db/mig-bug-18.sql
+++ b/maas-server/db/mig-bug-18.sql
@@ -1,0 +1,11 @@
+create table user_items_stats_dg_tmp
+					(
+					userID INTEGER,
+					itemID INTEGER not null,
+					consumed INTEGER not null,
+					constraint user_items_stats_pk
+					primary key (userID, itemID)
+					);
+insert into user_items_stats_dg_tmp(userID, itemID, consumed) select userID, itemID, consumed from user_items_stats;
+drop table user_items_stats;
+alter table user_items_stats_dg_tmp rename to user_items_stats;

--- a/maas-server/db/schema.sql
+++ b/maas-server/db/schema.sql
@@ -19,6 +19,13 @@ CREATE TABLE `user_items_stats` (
 	`itemID` INTEGER NOT NULL,
 	`consumed` INTEGER NOT NULL
 );
+CREATE TABLE `user_items_stats` (
+  `userID`INTEGER,
+  `itemID` INTEGER not null,
+  `consumed` INTEGER not null,
+  constraint user_items_stats_pk
+  primary key (userID, itemID)
+);
 CREATE TABLE `users` (
 	`ID` INTEGER PRIMARY KEY AUTOINCREMENT,
 	`username` VARCHAR(256) NOT NULL,


### PR DESCRIPTION
Schema definition for user_items_stats was not using a composite primary key. This resulted in the inability to insert more than a single row per user, as userID was the lone primary key. Added itemID to primary key.

To patch an existing database, use mig-bug-18.sql (e.g. sqlite3 matomat.db < mig-bug-18.sql)