### PR TITLE
Give the itemID to itemStatsRepo

### DIFF
--- a/maas-server/events/event_handler_stats_repos.go
+++ b/maas-server/events/event_handler_stats_repos.go
@@ -15,6 +15,6 @@ func NewEventHandlerStatsRepos(itemStatsRepo items.ItemStatsRepositoryInterface,
 }
 
 func (eh *EventHandlerStatsRepos) ItemConsumed(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) {
-	_, _ = eh.itemStatsRepo.CountConsumption(userID, count)
+	_, _ = eh.itemStatsRepo.CountConsumption(itemID, count)
 	_ = eh.userItemsStatsRepo.CountConsumption(userID, itemID, count)
 }


### PR DESCRIPTION
The consumptions of items were not correctly counted because the userID instead of the itemID was given to the stats method.