### PR TITLE
MQTT: making retain message configurable

### DIFF
--- a/maas-server/config.template.yml
+++ b/maas-server/config.template.yml
@@ -41,3 +41,4 @@ event_dispatching:
     topic: <NAME OF THE MQTT TOPIC, EXAMPLE: matomat>
     username: <USERNAME FOR MQTT BROKER>
     password: <PASSWORD FOR MQTT BROKER>
+    retain_messages: true

--- a/maas-server/server.go
+++ b/maas-server/server.go
@@ -119,11 +119,12 @@ func buildEventDispatcher(cfg *config.Config, itemStatsRepo items.ItemStatsRepos
 	if mqttEnabled {
 		mqttClientID, _ := cfg.String("event_dispatching.mqtt.client_id")
 		mqttConnectionString, _ := cfg.String("event_dispatching.mqtt.connection_string")
-		mqttTopic, _ := cfg.String("event_dispatching.mqtt.uopic")
+		mqttTopic, _ := cfg.String("event_dispatching.mqtt.topic")
 		mqttUsername, _ := cfg.String("event_dispatching.mqtt.username")
 		mqttPassword, _ := cfg.String("event_dispatching.mqtt.password")
+		mqttRetainMessage, _ := cfg.Bool("event_dispatching.mqtt.retain_messages")
 
-		eventHandlerMqtt := events.NewEventHandlerMqtt(mqttConnectionString, mqttClientID, mqttTopic, mqttUsername, mqttPassword)
+		eventHandlerMqtt := events.NewEventHandlerMqtt(mqttConnectionString, mqttClientID, mqttTopic, mqttUsername, mqttPassword, mqttRetainMessage)
 
 		dispatcher.Register(eventHandlerMqtt)
 	}


### PR DESCRIPTION
- Fixed broken way to access config value for MQTT topic
- Added usage of new config flag for MQTT client to allow configuration to retain messages