### PR TITLE
Feature/add timestamp and total items consumed to mqtt message

### DIFF
--- a/maas-server/README.md
+++ b/maas-server/README.md
@@ -36,8 +36,8 @@ go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 4096 --host 127.0.0.1,
 Example MQTT Messages
 
 ```
-'matomat;item-consumed;1;2;Bier;100;1'
-'matomat;item-consumed;1;1;Club Mate;100;1'
+'matomat;item-consumed;1;2;Bier;100;1;1556827023'
+'matomat;item-consumed;1;1;Club Mate;100;1;1556827042'
 ```
 
 ## Reference Links

--- a/maas-server/events/event_handler_interface.go
+++ b/maas-server/events/event_handler_interface.go
@@ -3,4 +3,8 @@ package events
 type EventHandlerInterface interface {
 	//TODO should the username be passed in????
 	ItemConsumed(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32)
+	//SORRY adding the following extension to the interface is an evil hack, abusing the concept
+	// but required to implement the desired behavior with minimal change
+	//If anybody feels like it, please feel free to improve!
+	TotalItemConsumedForUserChanged(userID uint32, username string, itemID uint32, itemName string, itemCost int32, totalCount uint32)
 }

--- a/maas-server/events/event_handler_interface.go
+++ b/maas-server/events/event_handler_interface.go
@@ -1,7 +1,6 @@
 package events
 
 type EventHandlerInterface interface {
-	//TODO add timestamp?
 	//TODO should the username be passed in????
 	ItemConsumed(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32)
 }

--- a/maas-server/events/event_handler_mqtt.go
+++ b/maas-server/events/event_handler_mqtt.go
@@ -3,6 +3,7 @@ package events
 import (
 	"log"
 	"strconv"
+	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 )
@@ -45,6 +46,6 @@ func (eh *EventHandlerMqtt) ItemConsumed(userID uint32, username string, itemID 
 func (eh *EventHandlerMqtt) buildItemConsumedMessage(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) string {
 	//TODO - shouldn't the username used instead of the user ID?
 	//TODO - the int casts are messy ... improve!
-	message := "matomat;item-consumed;" + strconv.Itoa(int(userID)) + ";" + strconv.Itoa(int(itemID)) + ";" + itemName + ";" + strconv.Itoa(int(itemCost)) + ";" + strconv.Itoa(int(count)) //TODO implement proper message format
+	message := "matomat;item-consumed;" + strconv.Itoa(int(userID)) + ";" + strconv.Itoa(int(itemID)) + ";" + itemName + ";" + strconv.Itoa(int(itemCost)) + ";" + strconv.Itoa(int(count)) + ";" + strconv.FormatInt(time.Now().Unix(), 10) //TODO implement proper message format
 	return message
 }

--- a/maas-server/events/event_handler_mqtt.go
+++ b/maas-server/events/event_handler_mqtt.go
@@ -28,6 +28,31 @@ func NewEventHandlerMqtt(connectionString string, clientID string, topic string,
 }
 
 func (eh *EventHandlerMqtt) ItemConsumed(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) {
+	eh.publishMessage(eh.buildItemConsumedMessage(userID, username, itemID, itemName, itemCost, count))
+}
+
+func (eh *EventHandlerMqtt) buildItemConsumedMessage(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) string {
+	//TODO - shouldn't the username used instead of the user ID?
+	//TODO - the int casts are messy ... improve!
+	message := "matomat;item-consumed;" + strconv.Itoa(int(userID)) + ";" + strconv.Itoa(int(itemID)) + ";" + itemName + ";" + strconv.Itoa(int(itemCost)) + ";" + strconv.Itoa(int(count)) + ";" + strconv.FormatInt(time.Now().Unix(), 10) //TODO implement proper message format
+	return message
+}
+
+//SORRY adding the following is an evil hack, abusing the concept
+// but required to implement the desired behavior with minimal change
+//If anybody feels like it, please feel free to improve!
+func (eh *EventHandlerMqtt) TotalItemConsumedForUserChanged(userID uint32, username string, itemID uint32, itemName string, itemCost int32, totalCount uint32) {
+	eh.publishMessage(eh.buildTotalItemConsumedForUserChanged(userID, username, itemID, itemName, itemCost, totalCount))
+}
+
+func (eh *EventHandlerMqtt) buildTotalItemConsumedForUserChanged(userID uint32, username string, itemID uint32, itemName string, itemCost int32, totalCount uint32) string {
+	//TODO - shouldn't the username used instead of the user ID?
+	//TODO - the int casts are messy ... improve!
+	message := "matomat;total-item-consumed-for-user-changed;" + strconv.Itoa(int(userID)) + ";" + strconv.Itoa(int(itemID)) + ";" + itemName + ";" + strconv.Itoa(int(itemCost)) + ";" + strconv.Itoa(int(totalCount)) + ";" + strconv.FormatInt(time.Now().Unix(), 10) //TODO implement proper message format
+	return message
+}
+
+func (eh *EventHandlerMqtt) publishMessage(message string) {
 	client := MQTT.NewClient(eh.clientOpts)
 	// connect to the broker using the mqtt client
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
@@ -36,16 +61,9 @@ func (eh *EventHandlerMqtt) ItemConsumed(userID uint32, username string, itemID 
 			log.Print("EventHandlerMqtt: error trying to connect to MQTT broker")
 		}
 	} else {
-		token := client.Publish(eh.topic, 0, eh.retainMessage, eh.buildItemConsumedMessage(userID, username, itemID, itemName, itemCost, count))
+		token := client.Publish(eh.topic, 0, eh.retainMessage, message)
 		//wait for receipt from broker
 		token.Wait()
 		client.Disconnect(250)
 	}
-}
-
-func (eh *EventHandlerMqtt) buildItemConsumedMessage(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) string {
-	//TODO - shouldn't the username used instead of the user ID?
-	//TODO - the int casts are messy ... improve!
-	message := "matomat;item-consumed;" + strconv.Itoa(int(userID)) + ";" + strconv.Itoa(int(itemID)) + ";" + itemName + ";" + strconv.Itoa(int(itemCost)) + ";" + strconv.Itoa(int(count)) + ";" + strconv.FormatInt(time.Now().Unix(), 10) //TODO implement proper message format
-	return message
 }

--- a/maas-server/events/event_handler_stats_repos.go
+++ b/maas-server/events/event_handler_stats_repos.go
@@ -8,13 +8,39 @@ import (
 type EventHandlerStatsRepos struct {
 	itemStatsRepo      items.ItemStatsRepositoryInterface
 	userItemsStatsRepo users.UserItemsStatsRepositoryInterface
+	//SORRY adding the following is an evil hack, abusing the concept
+	// but required to implement the desired behavior with minimal change
+	//If anybody feels like it, please feel free to improve!
+	eventHandlerMessaging EventHandlerInterface
 }
 
-func NewEventHandlerStatsRepos(itemStatsRepo items.ItemStatsRepositoryInterface, userItemsStatsRepo users.UserItemsStatsRepositoryInterface) *EventHandlerStatsRepos {
-	return &EventHandlerStatsRepos{itemStatsRepo: itemStatsRepo, userItemsStatsRepo: userItemsStatsRepo}
+func NewEventHandlerStatsRepos(itemStatsRepo items.ItemStatsRepositoryInterface, userItemsStatsRepo users.UserItemsStatsRepositoryInterface, eventHandlerMessaging EventHandlerInterface) *EventHandlerStatsRepos {
+	return &EventHandlerStatsRepos{itemStatsRepo: itemStatsRepo, userItemsStatsRepo: userItemsStatsRepo, eventHandlerMessaging: eventHandlerMessaging}
 }
 
 func (eh *EventHandlerStatsRepos) ItemConsumed(userID uint32, username string, itemID uint32, itemName string, itemCost int32, count uint32) {
 	_, _ = eh.itemStatsRepo.CountConsumption(itemID, count)
 	_ = eh.userItemsStatsRepo.CountConsumption(userID, itemID, count)
+
+	//SORRY adding the following is an evil hack, abusing the concept
+	// but required to implement the desired behavior with minimal change
+	//If anybody feels like it, please feel free to improve!
+	userItemStatsList, _ := eh.userItemsStatsRepo.Get(userID)
+
+	var totalCount uint32 = 0
+	for _, userItemStats := range userItemStatsList {
+		if userItemStats.ItemID == itemID {
+			totalCount = userItemStats.Consumed
+			break
+		}
+	}
+
+	eh.eventHandlerMessaging.TotalItemConsumedForUserChanged(userID, username, itemID, itemName, itemCost, totalCount)
+}
+
+//SORRY adding the following is an evil hack, abusing the concept
+// but required to implement the desired behavior with minimal change
+//If anybody feels like it, please feel free to improve!
+func (eh *EventHandlerStatsRepos) TotalItemConsumedForUserChanged(userID uint32, username string, itemID uint32, itemName string, itemCost int32, totalCount uint32) {
+	//do nothing ... as said, evil hack, badly implemented but will work
 }


### PR DESCRIPTION
Added bastard implementation of hell to implement the request for different mqtt messages. Fixes #30 
- Introduced new event `total-item-consumed-for-user-changed`
- Added timestamp to `item-consumed` event