### PR TITLE
Replace double quote with single quote

### DIFF
--- a/maas-server/db/initial_data.sql
+++ b/maas-server/db/initial_data.sql
@@ -1,1 +1,1 @@
-INSERT INTO users (username, password, credits, admin) VALUES ("admin", "$2a$10$ZCbKtezLIeBZqHqR40DR5.opcXpLYKs9KUDyfQRtEzBklpX.QWHjy", 0, 1);
+INSERT INTO users (username, password, credits, admin) VALUES ('admin', '$2a$10$ZCbKtezLIeBZqHqR40DR5.opcXpLYKs9KUDyfQRtEzBklpX.QWHjy', 0, 1);


### PR DESCRIPTION
Fix load of initial data into database by replacing double quotes with single quotes. Double quotes were allowed for some time but are deprecated, see [here](https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted). At least on Fedora, the feature of using double quotes is already disabled.